### PR TITLE
Fix bug where dollar amounts reported to BSD are 100x the actual amount

### DIFF
--- a/app/notifiers/blue_state_notifier.rb
+++ b/app/notifiers/blue_state_notifier.rb
@@ -4,12 +4,13 @@ class BlueStateNotifier
   def process(charge)
     organization = charge.organization
     crm = organization.crm
+    presentable_amount = Charge.presentation_amount(charge.converted_amount(crm.default_currency), crm.default_currency).to_f
     connection = BlueStateDigital::Connection.new(host: crm.host, api_id: crm.username, api_secret: crm.password)
     contribution = BlueStateDigital::Contribution.new(external_id: charge.id,
                                        firstname: charge.customer.first_name,
                                        lastname: charge.customer.last_name,
                                        transaction_dt: charge.created_at,
-                                       transaction_amt: charge.converted_amount(crm.default_currency),
+                                       transaction_amt: presentable_amount,
                                        cc_type_cd: CARD_MAPPING[charge.card['brand']],
                                        gateway_transaction_id: charge.stripe_id,
                                        source: 'takecharge',

--- a/spec/notifiers/blue_state_notifier_spec.rb
+++ b/spec/notifiers/blue_state_notifier_spec.rb
@@ -22,7 +22,7 @@ describe BlueStateNotifier do
     charge.amount = 123
     expect(charge).to receive(:converted_amount).with('XYZ').and_return(23456)
     expect(BlueStateDigital::Contribution).to receive(:new) do |options|
-      expect(options[:transaction_amt]).to eq(23456)
+      expect(options[:transaction_amt]).to eq(234.56)
       double().as_null_object
     end
     BlueStateNotifier.new.process(charge)


### PR DESCRIPTION
Based on testing, BSD expects us to tell it amounts like "1.00", not "100" (for 1 dollar or pound).
