### PR TITLE
Fix recalculation of day/month/year donation totals

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -88,10 +88,10 @@ class Charge < ActiveRecord::Base
       if paid_transition.first == false && paid_transition.last == true
         amt = self.converted_amount(self.organization.currency)
         # if a charge transitions to being paid, update the associated aggregate
-        DateAggregation.new(organization.total_raised_key).increment(amt)
-        DateAggregation.new(organization.total_charges_count_key).increment
+        DateAggregation.new(organization.total_raised_key).increment(amt, date: self.created_at)
+        DateAggregation.new(organization.total_charges_count_key).increment(date: self.created_at)
         self.tags.each do |tag|
-          tag.incrby(amt, self.status)
+          tag.incrby(amt, self.status, charge_date: self.created_at)
         end
       end
     end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -91,7 +91,7 @@ class Charge < ActiveRecord::Base
         DateAggregation.new(organization.total_raised_key).increment(amt, date: self.created_at)
         DateAggregation.new(organization.total_charges_count_key).increment(date: self.created_at)
         self.tags.each do |tag|
-          tag.incrby(amt, self.status, charge_date: self.created_at)
+          tag.incrby(amt, status: self.status, charge_date: self.created_at)
         end
       end
     end

--- a/app/models/date_aggregation.rb
+++ b/app/models/date_aggregation.rb
@@ -21,8 +21,8 @@ class DateAggregation
     stats
   end
 
-  def increment(amount = 1)
-    redis.multi { keys.each { |key| redis.incrby key, amount }}
+  def increment(amount = 1, date:)
+    redis.multi { keys(date).each { |key| redis.incrby key, amount }}
   end
 
   def today
@@ -51,7 +51,9 @@ class DateAggregation
     "#{month_key(month, year)}/day:#{day}"
   end
 
-  def keys
-    [year_key, month_key, day_key]
+  def keys(date)
+    [year_key(date.year),
+     month_key(date.month, date.year),
+     day_key(date.day, date.month, date.year)]
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -32,13 +32,13 @@ class Tag < ActiveRecord::Base
     name
   end
 
-  def incrby(amount, status='live')
-    DateAggregation.new(total_charges_count_key).increment
-    DateAggregation.new(total_raised_amount_key).increment(amount)
+  def incrby(amount, status='live', charge_date: Time.zone.today)
+    DateAggregation.new(total_charges_count_key).increment(date: charge_date)
+    DateAggregation.new(total_raised_amount_key).increment(amount, date: charge_date)
     redis.incr(total_charges_count_key(status))
     redis.incrby(total_raised_amount_key(status), amount)
     if namespace.present?
-      namespace.incrby(amount, name, status)
+      namespace.incrby(amount, name, status, charge_date: charge_date)
     end
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -32,13 +32,13 @@ class Tag < ActiveRecord::Base
     name
   end
 
-  def incrby(amount, status='live', charge_date: Time.zone.today)
+  def incrby(amount, status: 'live', charge_date: Time.zone.today)
     DateAggregation.new(total_charges_count_key).increment(date: charge_date)
     DateAggregation.new(total_raised_amount_key).increment(amount, date: charge_date)
     redis.incr(total_charges_count_key(status))
     redis.incrby(total_raised_amount_key(status), amount)
     if namespace.present?
-      namespace.incrby(amount, name, status, charge_date: charge_date)
+      namespace.incrby(amount, name, status: status, charge_date: charge_date)
     end
   end
 

--- a/app/models/tag_namespace.rb
+++ b/app/models/tag_namespace.rb
@@ -25,7 +25,7 @@ class TagNamespace < ActiveRecord::Base
     namespace
   end
 
-  def incrby(amount, name, status='live', charge_date: Time.zone.today)
+  def incrby(amount, name, status: 'live', charge_date: Time.zone.today)
     DateAggregation.new(total_charges_count_key(status)).increment(date: charge_date)
     DateAggregation.new(total_raised_amount_key(status)).increment(amount, date: charge_date)
     redis.zincrby(self.most_raised_key(status), amount, name)

--- a/app/models/tag_namespace.rb
+++ b/app/models/tag_namespace.rb
@@ -25,9 +25,9 @@ class TagNamespace < ActiveRecord::Base
     namespace
   end
 
-  def incrby(amount, name, status='live')
-    DateAggregation.new(total_charges_count_key(status)).increment
-    DateAggregation.new(total_raised_amount_key(status)).increment(amount)
+  def incrby(amount, name, status='live', charge_date: Time.zone.today)
+    DateAggregation.new(total_charges_count_key(status)).increment(date: charge_date)
+    DateAggregation.new(total_raised_amount_key(status)).increment(amount, date: charge_date)
     redis.zincrby(self.most_raised_key(status), amount, name)
     redis.incrby(self.total_raised_amount_key(status), amount)
     redis.incr(self.total_charges_count_key(status))

--- a/app/workers/calculate_organization_totals_worker.rb
+++ b/app/workers/calculate_organization_totals_worker.rb
@@ -15,7 +15,7 @@ class CalculateOrganizationTotalsWorker
 
     organization.charges.paid.find_each do |charge|
       charge.tags.find_each do |tag|
-        tag.incrby(charge.converted_amount(organization.currency), charge.status, charge_date: charge.created_at)
+        tag.incrby(charge.converted_amount(organization.currency), status: charge.status, charge_date: charge.created_at)
       end
     end
   end

--- a/app/workers/calculate_organization_totals_worker.rb
+++ b/app/workers/calculate_organization_totals_worker.rb
@@ -15,7 +15,7 @@ class CalculateOrganizationTotalsWorker
 
     organization.charges.paid.find_each do |charge|
       charge.tags.find_each do |tag|
-        tag.incrby(charge.converted_amount(organization.currency), charge.status)
+        tag.incrby(charge.converted_amount(organization.currency), charge.status, charge_date: charge.created_at)
       end
     end
   end

--- a/spec/models/tag_namespace_spec.rb
+++ b/spec/models/tag_namespace_spec.rb
@@ -62,6 +62,20 @@ describe TagNamespace do
         expect(tag_namespace.total_raised).to eq(100)
         expect(tag_namespace.raised_for_tag(tag)).to eq(100)
         expect(tag_namespace.most_raised).to eq([{:tag=>"foo", :raised=>100}])
+        expect(tag_namespace.raised_last_7_days[Time.zone.today]).to eq 100
+      end
+    end
+
+    context 'with a date' do
+      let(:charge_date) { Time.zone.today - 5.days }
+
+      before :each do
+        tag_namespace.incrby(amount, tag_name, charge_date: charge_date)
+      end
+
+      it 'should increment the date aggregation for the charge date' do
+        expect(tag_namespace.raised_last_7_days[charge_date]).to eq 100
+        expect(tag_namespace.raised_last_7_days[Time.zone.today]).to eq 0
       end
     end
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -65,6 +65,20 @@ describe Tag do
         expect(tag.total_charges_count).to eq(1)
         expect(tag.total_raised).to eq(100)
         expect(tag.average_charge_amount).to eq(100)
+        expect(tag.raised_last_7_days[Time.zone.today]).to eq 100
+      end
+    end
+
+    context 'with a date' do
+      let(:charge_date) { Time.zone.today - 5.days }
+
+      before :each do
+        tag.incrby(amount, charge_date: charge_date)
+      end
+
+      it 'should increment the date aggregation for the charge date' do
+        expect(tag.raised_last_7_days[charge_date]).to eq 100
+        expect(tag.raised_last_7_days[Time.zone.today]).to eq 0
       end
     end
 

--- a/spec/workers/calculate_organization_totals_worker_spec.rb
+++ b/spec/workers/calculate_organization_totals_worker_spec.rb
@@ -35,7 +35,7 @@ describe CalculateOrganizationTotalsWorker do
       expect(charge).to receive(:converted_amount).with(organization.currency).exactly(2).times.and_return(charge_amount)
 
       tags = build_stubbed_list(:tag, 2, organization: organization)
-      tags.each {|tag| expect(tag).to receive(:incrby).with(charge_amount, charge.status) }
+      tags.each {|tag| expect(tag).to receive(:incrby).with(charge_amount, charge.status, charge_date: charge.created_at) }
       tags_relation = double
       expect(tags_relation).to receive(:find_each) do |&block|
         tags.each(&block)

--- a/spec/workers/calculate_organization_totals_worker_spec.rb
+++ b/spec/workers/calculate_organization_totals_worker_spec.rb
@@ -35,7 +35,7 @@ describe CalculateOrganizationTotalsWorker do
       expect(charge).to receive(:converted_amount).with(organization.currency).exactly(2).times.and_return(charge_amount)
 
       tags = build_stubbed_list(:tag, 2, organization: organization)
-      tags.each {|tag| expect(tag).to receive(:incrby).with(charge_amount, charge.status, charge_date: charge.created_at) }
+      tags.each {|tag| expect(tag).to receive(:incrby).with(charge_amount, status: charge.status, charge_date: charge.created_at) }
       tags_relation = double
       expect(tags_relation).to receive(:find_each) do |&block|
         tags.each(&block)


### PR DESCRIPTION
This fixes a bug with the calculation of the year/month/day donation totals that meant recalculating tag stats attributed all donations to the day the recalculation was run, not the day the donation was made.

This does not attempt to address any existing redis storage implications from the year/month/day counts.