### PR TITLE
Stats recalculation: reset and re-sum all stats

### DIFF
--- a/app/models/date_aggregation.rb
+++ b/app/models/date_aggregation.rb
@@ -37,6 +37,12 @@ class DateAggregation
     redis.get(year_key).to_i
   end
 
+  def delete_all_redis_keys!
+    # Find and delete all redis keys that belong to DateAggregations on this stat
+    keys = redis.keys(year_key(''))
+    redis.del(*keys) unless keys.empty?
+  end
+
   private
 
   def year_key(year = Time.zone.now.year)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -43,7 +43,11 @@ class Tag < ActiveRecord::Base
   end
 
   def reset_redis_keys!
-    redis.del(total_raised_amount_key, total_charges_count_key)
+    DateAggregation.new(total_charges_count_key).delete_all_redis_keys!
+    DateAggregation.new(total_raised_amount_key).delete_all_redis_keys!
+    ['live', 'test'].each do |status|
+      redis.del(total_raised_amount_key(status), total_charges_count_key(status))
+    end
   end
 
   def total_raised(status='live')

--- a/app/models/tag_namespace.rb
+++ b/app/models/tag_namespace.rb
@@ -34,7 +34,11 @@ class TagNamespace < ActiveRecord::Base
   end
 
   def reset_redis_keys!
-    redis.del(total_raised_amount_key, total_charges_count_key, most_raised_key)
+    ['live', 'test'].each do |status|
+      DateAggregation.new(total_charges_count_key(status)).delete_all_redis_keys!
+      DateAggregation.new(total_raised_amount_key(status)).delete_all_redis_keys!
+      redis.del(total_raised_amount_key(status), total_charges_count_key(status), most_raised_key(status))
+    end
   end
 
   def total_raised(status='live')

--- a/app/workers/calculate_organization_totals_worker.rb
+++ b/app/workers/calculate_organization_totals_worker.rb
@@ -5,6 +5,10 @@ class CalculateOrganizationTotalsWorker
     organization = Organization.find(organization_id)
 
     # recalculate all of the totals in redis.
+    # clear out the organization's DateAggregation total_raised_key and total_charges_count_key
+    DateAggregation.new(organization.total_raised_key).delete_all_redis_keys!
+    DateAggregation.new(organization.total_charges_count_key).delete_all_redis_keys!
+
     organization.tags.find_each do |tag|
       tag.reset_redis_keys!
     end
@@ -14,8 +18,14 @@ class CalculateOrganizationTotalsWorker
     end
 
     organization.charges.paid.find_each do |charge|
+      # This mirrors the logic in Charge#update_aggregates
+      amt = charge.converted_amount(organization.currency)
+
+      DateAggregation.new(organization.total_raised_key).increment(amt, date: charge.created_at)
+      DateAggregation.new(organization.total_charges_count_key).increment(date: charge.created_at)
+
       charge.tags.find_each do |tag|
-        tag.incrby(charge.converted_amount(organization.currency), status: charge.status, charge_date: charge.created_at)
+        tag.incrby(amt, status: charge.status, charge_date: charge.created_at)
       end
     end
   end


### PR DESCRIPTION
This fixes several ways we were failing to reset all the redis keys or failing to re-count them back up.