### PR TITLE
Admin users list & edit page

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -1,9 +1,6 @@
 class Admin::AdminController < ApplicationController
   before_filter { authorize! :manage, :all }
-  def index
-  end
 
-  def error
-    raise "this is a test controller exception"
+  def index
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,7 +1,17 @@
 class Admin::UsersController < ApplicationController
   before_filter { authorize! :manage, :all }
 
-  before_filter :load_user
+  before_filter :load_user, only: [:send_confirmation_instructions]
+
+  def index
+    users_relation = if params[:admins].to_s == 'true'
+      User.where(admin: true)
+    else
+      User.all
+    end
+
+    @users = users_relation.paginate(per_page: 20, page: params[:page])
+  end
 
   def send_confirmation_instructions
     @user.send_confirmation_instructions

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,7 +1,7 @@
 class Admin::UsersController < ApplicationController
   before_filter { authorize! :manage, :all }
 
-  before_filter :load_user, only: [:send_confirmation_instructions]
+  before_filter :load_user, except: [:index]
 
   def index
     users_relation = if params[:admins].to_s == 'true'
@@ -13,6 +13,19 @@ class Admin::UsersController < ApplicationController
     @users = users_relation.paginate(per_page: 20, page: params[:page])
   end
 
+  def edit
+  end
+
+  def update
+    @user.assign_attributes(user_params)
+    if @user.save
+      redirect_to admin_users_path, notice: 'User successfully updated'
+    else
+      flash[:alert] = 'User not updated'
+      render :edit
+    end
+  end
+
   def send_confirmation_instructions
     @user.send_confirmation_instructions
   end
@@ -21,5 +34,9 @@ class Admin::UsersController < ApplicationController
 
   def load_user
     @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:admin)
   end
 end

--- a/app/views/admin/admin/index.html.haml
+++ b/app/views/admin/admin/index.html.haml
@@ -7,3 +7,5 @@
     = link_to 'PgHero', admin_pg_hero_path
   %li
     = link_to 'Organizations', admin_organizations_path
+  %li
+    = link_to 'Users', admin_users_path

--- a/app/views/admin/users/edit.html.haml
+++ b/app/views/admin/users/edit.html.haml
@@ -1,0 +1,10 @@
+.row
+  .col-lg-12
+    = breadcrumbs [['Admin', admin_path],
+                   ['Users']]
+
+    = title @user.email
+
+    = simple_form_for @user, url: admin_user_path(@user) do |form|
+      = form.input :admin, as: :boolean
+      = form.button :submit, 'Save', data: { disable_with: 'Saving...' }

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -1,0 +1,23 @@
+.row
+  .col-lg-12
+    = breadcrumbs [['Admin', admin_path],
+                   ['Users']]
+
+    = title 'Users'
+
+    .pull-right
+      %ul.nav.nav-pills
+        %li= link_to 'All', admin_users_path, class: "btn btn-default #{params[:admins].nil? ? 'active' : ''}"
+        %li= link_to 'Admins', admin_users_path(admins: true), class: "btn btn-default #{params[:admins].present? ? 'active' : ''}"
+
+    %table.table
+      %thead
+        %th Email
+        %th Organization
+        %th Admin
+
+      - @users.each do |user|
+        %tr
+          %td= link_to user.email, admin_user_path(user)
+          %td= link_to user.organization.name, admin_organization_path(user.organization)
+          %td= user.admin?

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -18,6 +18,6 @@
 
       - @users.each do |user|
         %tr
-          %td= link_to user.email, admin_user_path(user)
+          %td= link_to user.email, edit_admin_user_path(user)
           %td= link_to user.organization.name, admin_organization_path(user.organization)
           %td= user.admin?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,14 +68,13 @@ PragueServer::Application.routes.draw do
   root 'home#index'
 
   namespace :admin do
-    get '/error', to: 'admin#error'
     authenticate :user, lambda { |u| u.admin? } do
       get '/', to: 'admin#index'
       mount Sidekiq::Web, at: '/sidekiq'
       mount Blazer::Engine, at: '/blazer'
       mount PgHero::Engine, at: '/pghero'
       resources :organizations, only: [:index, :show]
-      resources :users, only: [:show] do
+      resources :users, only: [:show, :index] do
         member do
           post :send_confirmation_instructions
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,7 @@ PragueServer::Application.routes.draw do
       mount Blazer::Engine, at: '/blazer'
       mount PgHero::Engine, at: '/pghero'
       resources :organizations, only: [:index, :show]
-      resources :users, only: [:show, :index] do
+      resources :users, only: [:index, :edit, :update] do
         member do
           post :send_confirmation_instructions
         end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -26,4 +26,28 @@ describe Admin::UsersController do
       expect(assigns[:users]).to match_array([admin])
     end
   end
+
+  describe '#edit' do
+    let(:user) { create(:user) }
+
+    it 'should assign user and render edit template' do
+      get :edit, id: user
+
+      expect(response).to render_template(:edit)
+      expect(assigns[:user]).to eq user
+    end
+  end
+
+  describe '#update' do
+    let(:user) { create(:user) }
+
+    it 'should update user and redirect' do
+      patch :update, id: user, user: {admin: '1'}
+
+      expect(response).to redirect_to(admin_users_path)
+      expect(flash[:notice]).to eq 'User successfully updated'
+      user.reload
+      expect(user).to be_admin
+    end
+  end
 end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Admin::UsersController do
+  let(:admin) { create(:confirmed_user, admin: true) }
+
+  before :each do
+    sign_in admin
+  end
+
+  describe '#index' do
+    let!(:regular_users) { create_list(:user, 2, admin: false) }
+
+    it 'should list all users including admins if no param present' do
+      get :index
+
+      expect(response.status).to eq 200
+      expect(response).to render_template(:index)
+      expect(assigns[:users]).not_to be_nil
+      expect(assigns[:users]).to match_array(regular_users + [admin])
+    end
+
+    it 'should only list admins if param present' do
+      get :index, admins: true
+
+      expect(response.status).to eq 200
+      expect(assigns[:users]).to match_array([admin])
+    end
+  end
+end


### PR DESCRIPTION
## List page

<img width="1199" alt="screenshot 2017-07-12 09 29 21" src="https://user-images.githubusercontent.com/134911/28106587-b01357c4-66e4-11e7-9d87-5be83d3224a4.png">
<img width="1177" alt="screenshot 2017-07-12 09 29 29" src="https://user-images.githubusercontent.com/134911/28106589-b05803e2-66e4-11e7-803a-3b2e90199188.png">

## Edit page

<img width="1181" alt="screenshot 2017-07-12 09 29 43" src="https://user-images.githubusercontent.com/134911/28106588-b01f40de-66e4-11e7-9ba3-62e64f4044d0.png">

I realize edit page is not pretty, but didn't look right with any of the existing simple form wrappers and being an internal page I thought it made no sense to spend time trying to fix...