### PR TITLE
Sync tags to Stripe charge

### DIFF
--- a/app/actions/charge_customer_action.rb
+++ b/app/actions/charge_customer_action.rb
@@ -8,6 +8,11 @@ class ChargeCustomerAction
   end
 
   def call
+    tags_metadata = {}
+    charge.tags.each_with_index do |tag, index|
+      tags_metadata["takecharge-tag-#{index}"] = tag.name
+    end
+
     Stripe::Charge.create({
       amount: charge.amount,
       currency: charge.currency,
@@ -17,7 +22,7 @@ class ChargeCustomerAction
         'charge_id' => charge.id,
         'name' => charge.customer.full_name,
         'email' => charge.customer.email
-      },
+      }.merge(tags_metadata),
       description: "#{Time.zone.now.to_s} - #{charge.customer.id} - #{charge.organization.slug}"
     }, {api_key: access_token, stripe_account: charge.organization.stripe_user_id})
   end


### PR DESCRIPTION
Push tags associated with charge on Stripe's charge metadata.

<img width="549" alt="screenshot 2017-07-13 17 10 21" src="https://user-images.githubusercontent.com/134911/28173261-2fa7f148-67ee-11e7-9159-de250a6001e8.png">
