### PR TITLE
Upgraded attr_encrypted gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'sucker_punch'
 gem 'rack-cors', :require => 'rack/cors'
 
 gem 'devise'
-gem 'attr_encrypted'
+gem 'attr_encrypted', "~> 3.0.0"
 
 gem 'action_kit_rest', git: 'https://github.com/controlshift/action_kit_rest.git'
 gem 'blue_state_digital', git: 'https://github.com/controlshift/blue_state_digital.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,8 +71,8 @@ GEM
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 12.0)
     arel (6.0.4)
-    attr_encrypted (1.3.4)
-      encryptor (>= 1.3.0)
+    attr_encrypted (3.0.3)
+      encryptor (~> 3.0.0)
     autoprefixer-rails (6.5.0.2)
       execjs
     bcrypt (3.1.11)
@@ -151,7 +151,7 @@ GEM
     dotenv (0.10.0)
     dotenv-rails (0.10.0)
       dotenv (= 0.10.0)
-    encryptor (1.3.0)
+    encryptor (3.0.0)
     errbase (0.0.3)
     erubis (2.7.0)
     eventmachine (1.0.9.1)
@@ -467,7 +467,7 @@ DEPENDENCIES
   action_kit_rest!
   analytics-ruby
   annotate
-  attr_encrypted
+  attr_encrypted (~> 3.0.0)
   blazer
   blue_state_digital!
   bootstrap-sass
@@ -536,4 +536,4 @@ RUBY VERSION
    ruby 2.3.4p301
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/app/models/crm.rb
+++ b/app/models/crm.rb
@@ -29,6 +29,7 @@ class Crm < ActiveRecord::Base
   validates :platform, presence: true, inclusion: {in: ['actionkit', 'bluestate']}
   accepts_nested_attributes_for :import_stubs, allow_destroy: true
 
+  attr_encrypted :password_old, key: ENV["ENCRYPTOR_SECRET_KEY"], algorithm: 'aes-256-cbc', mode: :single_iv_and_salt, insecure_mode: true
   attr_encrypted :password, key: ENV["ENCRYPTOR_SECRET_KEY"]
 
   PLATFORMS = { 'actionkit' => 'ActionKit', 'bluestate' => 'Blue State Digital'}

--- a/config/initializers/attr_encrypted.rb
+++ b/config/initializers/attr_encrypted.rb
@@ -1,5 +1,5 @@
 # Makes sure you've set up all the necessary encryptor env variables
-ENV["ENCRYPTOR_SECRET_KEY"] = "xxx" if Rails.env.test?
+ENV["ENCRYPTOR_SECRET_KEY"] = "33ed5cc61b7909210dee772f9ac4cdec6a4f3052993b3ee928ae366556c4029aea610282051b047388cc4423a6ce14713199fe3d2250b8ee5825381c68a6365b" if Rails.env.test?
 if ENV["ENCRYPTOR_SECRET_KEY"].blank?
   raise ArgumentError, "Be sure to specify ENCRYPTOR_SECRET_KEY as an environment variable"
 end

--- a/db/migrate/20171003162404_migrate_encrypted_password_to_new_attr_encrypted_version.rb
+++ b/db/migrate/20171003162404_migrate_encrypted_password_to_new_attr_encrypted_version.rb
@@ -1,0 +1,22 @@
+class MigrateEncryptedPasswordToNewAttrEncryptedVersion < ActiveRecord::Migration
+  def up
+    rename_column :crms, :encrypted_password, :encrypted_password_old
+
+    add_column :crms, :encrypted_password, :string
+    add_column :crms, :encrypted_password_iv, :string
+
+    Crm.reset_column_information
+
+    Crm.find_each do |crm|
+      crm.password = crm.password_old
+      crm.save!
+    end
+  end
+
+  def down
+    remove_column :crms, :encrypted_password
+    remove_column :crms, :encrypted_password_iv
+
+    rename_column :crms, :encrypted_password_old, :encrypted_password
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170531173923) do
+ActiveRecord::Schema.define(version: 20171003162404) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,11 +105,13 @@ ActiveRecord::Schema.define(version: 20170531173923) do
     t.string   "donation_page_name"
     t.string   "host"
     t.string   "username"
-    t.string   "encrypted_password"
+    t.string   "encrypted_password_old"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "platform"
-    t.string   "default_currency",   default: "USD"
+    t.string   "default_currency",       default: "USD"
+    t.string   "encrypted_password"
+    t.string   "encrypted_password_iv"
   end
 
   add_index "crms", ["organization_id"], name: "index_crms_on_organization_id", using: :btree


### PR DESCRIPTION
These changes upgrade `attr_encrypted` to the latest version, migrating the data from old encryption into new one.
Once these changes are deployed we'll need to merge and deploy the `drop_old_attr_encrypted_columns` branch that drops the deprecated data.