### PR TITLE
Include amount in org currency in api list of charges for a tag

### DIFF
--- a/app/views/api/tags/charges/index.jbuilder
+++ b/app/views/api/tags/charges/index.jbuilder
@@ -1,8 +1,10 @@
 json.array! @charges do |charge|
-  json.(charge, :id, :amount, :currency, :charged_back_at, :created_at, :updated_at, :config, :status, :paid, :stripe_url)
-  json.display_amount charge.presentation_amount
-  json.display_amount_in_org_currency Charge.presentation_amount(charge.converted_amount(charge.organization.currency), charge.organization.currency)
-  json.tags do
-    json.array! charge.tags.collect { |t| t.name }
+  json.cache! [charge, charge.organization] do
+    json.(charge, :id, :amount, :currency, :charged_back_at, :created_at, :updated_at, :config, :status, :paid, :stripe_url)
+    json.display_amount charge.presentation_amount
+    json.display_amount_in_org_currency Charge.presentation_amount(charge.converted_amount(charge.organization.currency), charge.organization.currency)
+    json.tags do
+      json.array! charge.tags.collect { |t| t.name }
+    end
   end
 end

--- a/app/views/api/tags/charges/index.jbuilder
+++ b/app/views/api/tags/charges/index.jbuilder
@@ -1,6 +1,7 @@
 json.array! @charges do |charge|
   json.(charge, :id, :amount, :currency, :charged_back_at, :created_at, :updated_at, :config, :status, :paid, :stripe_url)
   json.display_amount charge.presentation_amount
+  json.display_amount_in_org_currency Charge.presentation_amount(charge.converted_amount(charge.organization.currency), charge.organization.currency)
   json.tags do
     json.array! charge.tags.collect { |t| t.name }
   end

--- a/spec/controllers/api/tags/charges_controller_spec.rb
+++ b/spec/controllers/api/tags/charges_controller_spec.rb
@@ -39,5 +39,14 @@ describe Api::Tags::ChargesController do
       get :index, params: { tag_id: tag.name }
       expect(JSON.parse(response.body).first).to have_key('stripe_url')
     end
+
+    context 'charge is in a different currency' do
+      let!(:charge) { create(:charge, currency: 'GBP', organization: organization, paid: true)}
+
+      it 'should include the displayable converted amount in the org currency' do
+        get :index, params: { tag_id: tag.name }
+        expect(JSON.parse(response.body).first['display_amount_in_org_currency']).to eq Charge.presentation_amount(charge.converted_amount(organization.currency), organization.currency)
+      end
+    end
   end
 end


### PR DESCRIPTION
This updates the `/api/tags/foo/charges` endpoint to add, for each charge, the amount in the organisation's default currency. This is so that if clients need to do some calculations on the list of charges, they have the data in consistent units.

Q: What kind of calculations are we talking about? Can't they use the stats provided in `/api/tags/foo`?
A: While those stats provide _some_ helpful data for clients (e.g. total amount of donations with this tag), there are other calculations clients might be interested in. For example: Within the `foo` tag, what portion of donations were also tagged with `bar`? Rather than bookkeep all possible statistics, we're providing this data so clients can calculate what they need.