### PR TITLE
Configure sidekiq to pull from mailers queue in addition to default queue

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,3 @@
+:queues:
+  - [mailers, 2]
+  - default


### PR DESCRIPTION
I tested this locally and it fixed the problem where the mailers queue was not processed.